### PR TITLE
docs: initial templates, scripts PS, .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Variables sans secrets
+
+APP_NAME=CoulissesCrew
+ENV=dev
+LOG_LEVEL=INFO
+API_PORT=8001
+FRONT_PORT=4000
+DB_DSN=sqlite:///local.db
+JWT_ALG=HS256
+REQUEST_ID_HEADER=X-Request-ID

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,16 @@
+name: Bug report
+description: Signaler un bug
+title: "[BUG] Titre concis"
+labels: ["bug"]
+body:
+
+* type: textarea
+  attributes:
+  label: Repro
+  description: Commandes exactes et logs
+* type: textarea
+  attributes:
+  label: Attendu vs Observe
+* type: input
+  attributes:
+  label: Version/commit

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+name: Feature request
+description: Demande de fonctionnalite
+title: "[FEAT] Titre concis"
+labels: ["enhancement"]
+body:
+
+* type: textarea
+  attributes:
+  label: Contexte
+* type: textarea
+  attributes:
+  label: Critere d acceptance

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Objet
+
+Decrire le changement (court).
+
+## Type
+
+* [ ] feat
+* [ ] fix
+* [ ] chore
+* [ ] docs
+
+## Tests
+
+* [ ] Tests OK/KO ajoutes
+* [ ] Lints OK
+
+## Checklist
+
+* [ ] ASCII uniquement
+* [ ] PR <= 300 lignes (hors lockfiles)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# web
+# Coulisses Crew
+
+Projet SaaS de planification pour intermittents du spectacle.
+Windows-first (PowerShell). ASCII uniquement.
+
+## Objectifs
+
+* Planification missions et disponibilites
+* Comptabilite de base
+* Export CSV/PDF/ICS
+* Observabilite et securite par defaut
+
+## Arborescence
+
+* docs: documentation projet
+* scripts/ps1: scripts PowerShell utilitaires
+* .github: templates PR/issues
+
+## Demos locales
+
+Consulter docs/OPS_WINDOWS.md pour les commandes.
+
+## Contribution
+
+Lire docs/CONTRIBUTING.md.
+
+## Roadmap
+
+Voir docs/ROADMAP.md.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## Vue d ensemble
+
+* Frontend: React + TypeScript + Vite + Tailwind (UI compatibles shadcn)
+* Backend: FastAPI (Python 3.11+), SQLAlchemy, Alembic, Pydantic v2
+* DB: a definir (SQLite dev, Postgres prod)
+* Auth: JWT
+* Observabilite: logs JSON, request_id
+
+## Principes
+
+* Windows-first: scripts .ps1
+* Separation nette front/back
+* Validation stricte (Pydantic v2)
+* Perf Gate p95 < 500 ms (endpoints critiques)
+
+## Conventions
+
+* ASCII uniquement
+* Headers securite, rate limit
+* Pagination par defaut sur les listes

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+* Respect, collaboration, bienveillance.
+* Aucun contenu illegal, haineux, ou discriminant.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Regles
+
+* ASCII uniquement
+* Windows-first
+* PR <= 300 lignes (hors lockfiles)
+* Tests OK/KO pour chaque point critique
+
+## Commits
+
+* Conventional Commits
+* Exemple: feat(api): add missions publish
+
+## PR
+
+* Utiliser le template
+* CI verte obligatoire

--- a/docs/OPS_LINUX.md
+++ b/docs/OPS_LINUX.md
@@ -1,0 +1,4 @@
+# OPS Linux
+
+Les scripts officiels sont PowerShell.
+Equivalent bash optionnel a venir. Utiliser pwsh si necessaire.

--- a/docs/OPS_WINDOWS.md
+++ b/docs/OPS_WINDOWS.md
@@ -1,0 +1,24 @@
+# OPS Windows
+
+## Prerequis
+
+* PowerShell 5.1+ ou PowerShell 7+
+* Git
+* Python 3.11+ et Node LTS (prochaines etapes)
+
+## Scripts
+
+```powershell
+# Generer/maj docs
+.\scripts\ps1\New-Docs.ps1
+
+# Formater fichiers simples (fin de ligne, trimming)
+.\scripts\ps1\Format-Docs.ps1
+
+# Verifier presence fichiers, ASCII, lignes > 120
+.\scripts\ps1\Test-Docs.ps1
+```
+
+## Codes retour
+
+0 OK; 1 USAGE_INVALIDE; 2 PREREQUIS_MANQUANTS; 10 ERREUR_INTERNE.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,18 @@
+# Release
+
+## Versioning
+
+* SemVer: MAJOR.MINOR.PATCH
+* Conventional Commits
+
+## Procedure
+
+1. Maj CHANGELOG (auto dans etapes futures)
+2. Tag git vX.Y.Z
+3. Build artefacts (front/back)
+4. Publier release notes
+
+## Checks
+
+* CI verte (tests, lints, audits)
+* SBOM et secret scan passes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,21 @@
+# Roadmap
+
+## Gates principaux
+
+* ETAPE 0: Docs/charte/templates -> PR docs verte
+* ETAPE 1: CLI cc bootstrap -> cc ping
+* ETAPE 2: FastAPI skeleton + healthz
+* ETAPE 3: Auth JWT
+* ETAPE 4: Users CRUD + pagination
+* ETAPE 5: Intermittents CRUD + recherche
+* ETAPE 6: Missions CRUD + publication/duplication
+* ETAPE 7: Disponibilites + conflits
+* ETAPE 8: Audit log global
+* ETAPE 9..11: Frontend pages
+* ETAPE 12: SMTP + Telegram
+* ETAPE 13: Comptabilite
+* ETAPE 14: Exports CSV/PDF/ICS
+* ETAPE 15: k6 1000 VUs
+* ETAPE 16: Securite (audits deps)
+* ETAPE 17: Observabilite (traces/logs)
+* ETAPE 18..20: CI/CD + releases

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,12 @@
+# Securite
+
+## Principes
+
+* Pas de secrets dans le repo
+* Variables via .env local (exemple ci-joint)
+* Audits deps (pip-audit, npm audit)
+* Secret scan (gitleaks), SBOM
+
+## Signalement
+
+Ouvrir un ticket via "Security" ou contacter les maintainers.

--- a/scripts/ps1/Format-Docs.ps1
+++ b/scripts/ps1/Format-Docs.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Trim-File($path){
+$lines = Get-Content $path -Encoding ASCII
+$lines = $lines | ForEach-Object { $_.TrimEnd() }
+$out = [string]::Join([Environment]::NewLine, $lines)
+$out | Out-File -FilePath $path -Encoding ASCII -NoNewline
+}
+
+$targets = @(
+"README.md",
+"docs\*.md",
+".github\*\*\*.md",
+".env.example"
+)
+
+foreach($t in $targets){
+Get-ChildItem -Path $t -File -Recurse -ErrorAction SilentlyContinue | ForEach-Object {
+Trim-File $_.FullName
+Write-Host "[OK] Formate: $($_.FullName)" -ForegroundColor Green
+}
+}
+exit 0

--- a/scripts/ps1/New-Docs.ps1
+++ b/scripts/ps1/New-Docs.ps1
@@ -1,0 +1,119 @@
+Param(
+[switch]$Force
+)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Write-Ok($m){ Write-Host "[OK] $m" -ForegroundColor Green }
+function Write-Err($m){ Write-Host "[ERR] $m" -ForegroundColor Red }
+
+try {
+$root = Split-Path -Parent $PSCommandPath
+$repoRoot = Resolve-Path (Join-Path $root "....")
+Set-Location $repoRoot
+
+$files = @(
+    "README.md",
+    "docs\ARCHITECTURE.md",
+    "docs\ROADMAP.md",
+    "docs\RELEASE.md",
+    "docs\CONTRIBUTING.md",
+    "docs\OPS_WINDOWS.md",
+    "docs\OPS_LINUX.md",
+    "docs\SECURITY.md",
+    "docs\CODE_OF_CONDUCT.md",
+    ".env.example",
+    ".github\pull_request_template.md",
+    ".github\ISSUE_TEMPLATE\bug_report.md",
+    ".github\ISSUE_TEMPLATE\feature_request.md"
+)
+
+foreach($f in $files){
+    $dir = Split-Path $f -Parent
+    if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir | Out-Null }
+
+    if((Test-Path $f) -and -not $Force){
+        Write-Ok "$f existe, passer (--Force pour ecraser)."
+        continue
+    }
+
+    switch ($f){
+        "README.md" { @"
+# Coulisses Crew
+
+Projet SaaS de planification pour intermittents. Voir docs/.
+"@ | Out-File -FilePath $f -Encoding ASCII -NoNewline }
+        "docs\ARCHITECTURE.md" { @"
+# Architecture
+
+Voir README principal pour le resume.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\ROADMAP.md" { @"
+# Roadmap
+
+Voir gates par etapes.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\RELEASE.md" { @"
+# Release
+
+Procedure de versionnage.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\CONTRIBUTING.md" { @"
+# Contributing
+
+ASCII, Windows-first, PR <= 300 lignes.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\OPS_WINDOWS.md" { @"
+# OPS Windows
+
+Scripts PowerShell dans scripts/ps1.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\OPS_LINUX.md" { @"
+# OPS Linux
+
+Utiliser pwsh si besoin. Scripts officiels .ps1.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\SECURITY.md" { @"
+# Securite
+
+Pas de secrets commit.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        "docs\CODE_OF_CONDUCT.md" { @"
+# Code of Conduct
+
+Respect et collaboration.
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        ".env.example" { @"
+APP_NAME=CoulissesCrew
+ENV=dev
+LOG_LEVEL=INFO
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        ".github\pull_request_template.md" { @"
+## Objet
+
+Decrire le changement (court).
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        ".github\ISSUE_TEMPLATE\bug_report.md" { @"
+name: Bug report
+description: Signaler un bug
+title: ""[BUG] Titre concis""
+labels: [""bug""]
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+        ".github\ISSUE_TEMPLATE\feature_request.md" { @"
+name: Feature request
+description: Demande de fonctionnalite
+title: ""[FEAT] Titre concis""
+labels: [""enhancement""]
+"@ | Out-File $f -Encoding ASCII -NoNewline }
+    }
+    Write-Ok "Genere: $f"
+}
+
+Write-Ok "Docs initiales generees."
+exit 0
+
+}
+catch {
+Write-Err $_.Exception.Message
+exit 10
+}

--- a/scripts/ps1/Test-Docs.ps1
+++ b/scripts/ps1/Test-Docs.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Fail($code, $msg){ Write-Host "[FAIL] $msg" -ForegroundColor Red; exit $code }
+function Ok($msg){ Write-Host "[OK] $msg" -ForegroundColor Green }
+
+# EXIT_CODES
+
+# 0 OK; 1 USAGE_INVALIDE; 2 PREREQUIS_MANQUANTS; 10 ERREUR_INTERNE.
+
+try {
+$required = @(
+"README.md",
+"docs\ARCHITECTURE.md",
+"docs\ROADMAP.md",
+"docs\RELEASE.md",
+"docs\CONTRIBUTING.md",
+"docs\OPS_WINDOWS.md",
+"docs\OPS_LINUX.md",
+"docs\SECURITY.md",
+"docs\CODE_OF_CONDUCT.md",
+".env.example",
+".github\pull_request_template.md",
+".github\ISSUE_TEMPLATE\bug_report.md",
+".github\ISSUE_TEMPLATE\feature_request.md"
+)
+
+foreach($f in $required){
+    if(-not (Test-Path $f)){ Fail 2 "Fichier manquant: $f" } else { Ok "Present: $f" }
+    $bytes = [System.IO.File]::ReadAllBytes($f)
+    foreach($b in $bytes){ if($b -gt 127){ Fail 1 "Non-ASCII detecte dans $f" } }
+    $lines = Get-Content $f -Encoding ASCII
+    $i=0
+    foreach($line in $lines){ $i++; if($line.Length -gt 120){ Fail 1 "Ligne >120 chars: $f:$i" } }
+}
+
+Ok "Verification docs OK."
+exit 0
+
+}
+catch {
+Fail 10 $_.Exception.Message
+}


### PR DESCRIPTION
## Summary
- scaffold documentation (architecture, roadmap, release, contributing, ops, security, conduct)
- add PR/issue templates and `.env.example`
- add PowerShell scripts to generate, format and test docs

## Testing
- `pwsh -NoLogo -NoProfile -File scripts/ps1/New-Docs.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File scripts/ps1/Format-Docs.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File scripts/ps1/Test-Docs.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86fb7279883309517023f40232a8a