### PR TITLE
feat(missions): CRUD + publish/duplicate + audit log

### DIFF
--- a/backend/alembic/versions/20250822_0003_create_missions_audit.py
+++ b/backend/alembic/versions/20250822_0003_create_missions_audit.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20250822_0003"
+down_revision = "20250822_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "missions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("start_at", sa.DateTime(), nullable=False),
+        sa.Column("end_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "is_published",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("request_id", sa.String(length=100), nullable=False),
+        sa.Column("actor", sa.String(length=320), nullable=False),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column("entity", sa.String(length=50), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=True),
+        sa.Column("payload", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index("ix_audit_logs_request_id", "audit_logs", ["request_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_logs_request_id", table_name="audit_logs")
+    op.drop_table("audit_logs")
+    op.drop_table("missions")

--- a/backend/app/audit_log.py
+++ b/backend/app/audit_log.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from .middleware import get_request_id
+from .models_audit import AuditLog
+
+
+def write_audit_log(
+    db: Session,
+    actor: str,
+    action: str,
+    entity: str,
+    entity_id: int | None,
+    payload: Any,
+) -> None:
+    log = AuditLog(
+        request_id=get_request_id(),
+        actor=actor,
+        action=action,
+        entity=entity,
+        entity_id=entity_id,
+        payload=json.dumps(payload, default=str) if payload is not None else None,
+    )
+    db.add(log)
+    db.commit()

--- a/backend/app/crud_mission.py
+++ b/backend/app/crud_mission.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from .models_mission import Mission
+
+
+def list_missions(
+    db: Session,
+    q: str | None,
+    page: int,
+    size: int,
+) -> tuple[Sequence[Mission], int]:
+    if page < 1:
+        page = 1
+    size = max(1, min(size, 100))
+    offset = (page - 1) * size
+
+    query = select(Mission)
+    if q:
+        pattern = f"%{q.lower()}%"
+        query = query.where(func.lower(Mission.title).like(pattern))
+    total = db.scalar(select(func.count()).select_from(query.subquery()))
+    rows = db.scalars(query.offset(offset).limit(size)).all()
+    return rows, int(total or 0)
+
+
+def create_mission(
+    db: Session,
+    title: str,
+    start_at: datetime,
+    end_at: datetime,
+) -> Mission:
+    m = Mission(title=title, start_at=start_at, end_at=end_at, is_published=False)
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    return m
+
+
+def get_mission(db: Session, mission_id: int) -> Mission | None:
+    return db.get(Mission, mission_id)
+
+
+def update_mission(db: Session, mission_id: int, **changes) -> Mission | None:
+    m = db.get(Mission, mission_id)
+    if not m:
+        return None
+    for k, v in changes.items():
+        if v is not None:
+            setattr(m, k, v)
+    db.commit()
+    db.refresh(m)
+    return m
+
+
+def delete_mission(db: Session, mission_id: int) -> bool:
+    m = db.get(Mission, mission_id)
+    if not m:
+        return False
+    db.delete(m)
+    db.commit()
+    return True
+
+
+def publish_mission(db: Session, mission_id: int) -> Mission | None:
+    m = db.get(Mission, mission_id)
+    if not m:
+        return None
+    if not m.is_published:
+        m.is_published = True
+        db.commit()
+        db.refresh(m)
+    return m
+
+
+def duplicate_mission(db: Session, mission_id: int) -> Mission | None:
+    m = db.get(Mission, mission_id)
+    if not m:
+        return None
+    m2 = Mission(
+        title=m.title,
+        start_at=m.start_at,
+        end_at=m.end_at,
+        is_published=False,
+    )
+    db.add(m2)
+    db.commit()
+    db.refresh(m2)
+    return m2

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from .db import get_engine
 from .logging_setup import configure_logging, get_logger
 from .middleware import RequestIdMiddleware, get_request_id
 from .routers_intermittents import router as intermittents_router  # type: ignore[import-untyped]
+from .routers_missions import router as missions_router  # type: ignore[import-untyped]
 from .routers_users import router as users_router
 from .settings import get_settings
 
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router)
     app.include_router(users_router)
     app.include_router(intermittents_router)
+    app.include_router(missions_router)
 
     return app
 

--- a/backend/app/models_audit.py
+++ b/backend/app/models_audit.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .db import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    request_id: Mapped[str] = mapped_column(String(100), index=True, nullable=False)
+    actor: Mapped[str] = mapped_column(String(320), nullable=False)
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity: Mapped[str] = mapped_column(String(50), nullable=False)
+    entity_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    payload: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )

--- a/backend/app/models_mission.py
+++ b/backend/app/models_mission.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .db import Base
+
+
+class Mission(Base):
+    __tablename__ = "missions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    start_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    end_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    is_published: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)

--- a/backend/app/routers_missions.py
+++ b/backend/app/routers_missions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+
+from .audit_log import write_audit_log
+from .crud_mission import (
+    create_mission,
+    delete_mission,
+    duplicate_mission,
+    get_mission,
+    list_missions,
+    publish_mission,
+    update_mission,
+)
+from .deps import get_db_dep, require_auth
+from .schemas_mission import MissionCreate, MissionOut, MissionUpdate
+
+router = APIRouter(prefix="/missions", tags=["missions"])
+
+
+@router.get("", response_model=dict)
+def list_missions_api(
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    _: str = Depends(require_auth),  # noqa: B008
+    q: str | None = Query(default=None),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+) -> dict[str, Any]:
+    items, total = list_missions(db, q, page, size)
+    pages = (total + size - 1) // size if size else 1
+    return {
+        "items": [MissionOut.model_validate(i) for i in items],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": pages,
+    }
+
+
+@router.post("", response_model=MissionOut, status_code=201)
+def create_mission_api(
+    payload: MissionCreate,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    actor: str = Depends(require_auth),  # noqa: B008
+) -> MissionOut:
+    m = create_mission(db, payload.title, payload.start_at, payload.end_at)
+    write_audit_log(db, actor, "create", "mission", m.id, payload.model_dump())
+    return MissionOut.model_validate(m)
+
+
+@router.get("/{mission_id}", response_model=MissionOut)
+def get_mission_api(
+    mission_id: int,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    _: str = Depends(require_auth),  # noqa: B008
+) -> MissionOut:
+    m = get_mission(db, mission_id)
+    if not m:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mission introuvable.",
+        )
+    return MissionOut.model_validate(m)
+
+
+@router.put("/{mission_id}", response_model=MissionOut)
+def update_mission_api(
+    mission_id: int,
+    payload: MissionUpdate,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    actor: str = Depends(require_auth),  # noqa: B008
+) -> MissionOut:
+    m = update_mission(
+        db,
+        mission_id,
+        title=payload.title,
+        start_at=payload.start_at,
+        end_at=payload.end_at,
+    )
+    if not m:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mission introuvable.",
+        )
+    write_audit_log(db, actor, "update", "mission", m.id, payload.model_dump(exclude_unset=True))
+    return MissionOut.model_validate(m)
+
+
+@router.delete("/{mission_id}", status_code=204, response_class=Response)
+def delete_mission_api(
+    mission_id: int,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    actor: str = Depends(require_auth),  # noqa: B008
+) -> Response:
+    ok = delete_mission(db, mission_id)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mission introuvable.",
+        )
+    write_audit_log(db, actor, "delete", "mission", mission_id, None)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{mission_id}/publish", response_model=MissionOut)
+def publish_mission_api(
+    mission_id: int,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    actor: str = Depends(require_auth),  # noqa: B008
+) -> MissionOut:
+    m = publish_mission(db, mission_id)
+    if not m:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mission introuvable.",
+        )
+    write_audit_log(db, actor, "publish", "mission", m.id, None)
+    return MissionOut.model_validate(m)
+
+
+@router.post("/{mission_id}/duplicate", response_model=MissionOut, status_code=201)
+def duplicate_mission_api(
+    mission_id: int,
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    actor: str = Depends(require_auth),  # noqa: B008
+) -> MissionOut:
+    m = duplicate_mission(db, mission_id)
+    if not m:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Mission introuvable.",
+        )
+    write_audit_log(db, actor, "duplicate", "mission", m.id, {"source_id": mission_id})
+    return MissionOut.model_validate(m)

--- a/backend/app/schemas_mission.py
+++ b/backend/app/schemas_mission.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, model_validator
+
+
+class MissionCreate(BaseModel):
+    title: str
+    start_at: datetime
+    end_at: datetime
+
+    @model_validator(mode="after")
+    def check_dates(self) -> MissionCreate:
+        if self.end_at <= self.start_at:
+            raise ValueError("end_at must be after start_at")
+        return self
+
+
+class MissionUpdate(BaseModel):
+    title: str | None = None
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def check_dates(self) -> MissionUpdate:
+        if self.start_at and self.end_at and self.end_at <= self.start_at:
+            raise ValueError("end_at must be after start_at")
+        return self
+
+
+class MissionOut(BaseModel):
+    id: int
+    title: str
+    start_at: datetime
+    end_at: datetime
+    is_published: bool
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_missions.py
+++ b/backend/tests/test_missions.py
@@ -1,0 +1,97 @@
+import os
+from datetime import datetime, timedelta
+
+import pytest  # noqa: F401
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from app.db import Base, get_engine, session_scope
+from app.main import create_app
+from app.models_audit import AuditLog
+from app.settings import get_settings
+
+
+def _make_client():
+    os.environ["ADMIN_EMAIL"] = "admin@example.com"
+    os.environ["ADMIN_PASSWORD"] = "s3cret"
+    os.environ["JWT_SECRET"] = "unit-test-secret"
+    os.environ["DB_DSN"] = "sqlite://"
+    try:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    app = create_app()
+    return TestClient(app)
+
+
+def _login_token(c: TestClient) -> str:
+    r = c.post(
+        "/auth/token",
+        data={"username": "admin@example.com", "password": "s3cret"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def test_missions_create_publish_audit_ok():
+    c = _make_client()
+    token = _login_token(c)
+    auth = {"Authorization": f"Bearer {token}"}
+    now = datetime.utcnow()
+    payload = {
+        "title": "Show",
+        "start_at": (now + timedelta(hours=1)).isoformat(),
+        "end_at": (now + timedelta(hours=2)).isoformat(),
+    }
+    r = c.post("/missions", json=payload, headers=auth)
+    assert r.status_code == 201, r.text
+    rid_create = r.headers["X-Request-ID"]
+    mid = r.json()["id"]
+    r2 = c.post(f"/missions/{mid}/publish", headers=auth)
+    assert r2.status_code == 200
+    rid_publish = r2.headers["X-Request-ID"]
+    with session_scope() as db:
+        actions_create = db.scalars(
+            select(AuditLog.action).where(AuditLog.request_id == rid_create)
+        ).all()
+        actions_publish = db.scalars(
+            select(AuditLog.action).where(AuditLog.request_id == rid_publish)
+        ).all()
+    assert actions_create == ["create"]
+    assert actions_publish == ["publish"]
+
+
+def test_missions_duplicate_search_ok():
+    c = _make_client()
+    token = _login_token(c)
+    auth = {"Authorization": f"Bearer {token}"}
+    now = datetime.utcnow()
+    payload = {
+        "title": "Concert",
+        "start_at": (now + timedelta(hours=1)).isoformat(),
+        "end_at": (now + timedelta(hours=2)).isoformat(),
+    }
+    r = c.post("/missions", json=payload, headers=auth)
+    mid = r.json()["id"]
+    r2 = c.post(f"/missions/{mid}/duplicate", headers=auth)
+    assert r2.status_code == 201
+    r3 = c.get("/missions?q=Concert", headers=auth)
+    assert r3.status_code == 200
+    assert len(r3.json()["items"]) == 2
+
+
+def test_missions_publish_404():
+    c = _make_client()
+    token = _login_token(c)
+    r = c.post("/missions/9999/publish", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 404
+
+
+def test_missions_duplicate_404():
+    c = _make_client()
+    token = _login_token(c)
+    r = c.post("/missions/9999/duplicate", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 404

--- a/scripts/ps1/Backend-Test.ps1
+++ b/scripts/ps1/Backend-Test.ps1
@@ -15,7 +15,7 @@ $Env:PYTHONPATH = "backend"
 
 Must 0 "python -m ruff check backend"
 Must 0 "python -m mypy backend"
-Must 0 "pytest -q --cov=backend -k 'healthz or auth or users or intermittents'"
+Must 0 "pytest -q --cov=backend -k 'healthz or auth or users or intermittents or missions'"
 
 Write-Host "[OK] Tests backend passes" -ForegroundColor Green
 exit 0


### PR DESCRIPTION
## Summary
- add missions model, CRUD, publish/duplicate endpoints
- log audit entries for mission actions
- cover missions CRUD and auditing with tests and migration

## Testing
- `python -m ruff check backend`
- `python -m mypy backend`
- `PYTHONPATH=backend pytest -q --cov=backend -k 'healthz or auth or users or intermittents or missions'`
- `PYTHONPATH=backend uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8001`

------
https://chatgpt.com/codex/tasks/task_e_68a8892ef93c8330bdb38e91416b3b4c