### PR TITLE
feat(planning): availabilities CRUD + conflicts check endpoint + tests

### DIFF
--- a/backend/alembic/versions/20250822_0004_create_availabilities.py
+++ b/backend/alembic/versions/20250822_0004_create_availabilities.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250822_0004"
+down_revision = "20250822_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "availabilities",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("intermittent_id", sa.Integer(), nullable=False),
+        sa.Column("start_at", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("end_at", sa.DateTime(timezone=False), nullable=False),
+        sa.Column("busy", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("note", sa.String(length=200), nullable=True),
+    )
+    op.create_index("ix_avail_inter_id", "availabilities", ["intermittent_id"])
+    op.create_index("ix_avail_time", "availabilities", ["start_at", "end_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_avail_time", table_name="availabilities")
+    op.drop_index("ix_avail_inter_id", table_name="availabilities")
+    op.drop_table("availabilities")

--- a/backend/app/crud_availability.py
+++ b/backend/app/crud_availability.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from .models_availability import Availability
+
+
+def list_availabilities(
+    db: Session,
+    page: int,
+    size: int,
+    intermittent_id: int | None = None,
+    start_from: str | None = None,
+    end_to: str | None = None,
+) -> tuple[Sequence[Availability], int]:
+    if page < 1:
+        page = 1
+    size = max(1, min(size, 100))
+    offset = (page - 1) * size
+
+    stmt = select(Availability)
+    if intermittent_id is not None:
+        stmt = stmt.where(Availability.intermittent_id == intermittent_id)
+    if start_from is not None:
+        stmt = stmt.where(Availability.end_at >= start_from)  # ends after window start
+    if end_to is not None:
+        stmt = stmt.where(Availability.start_at <= end_to)  # starts before window end
+
+    total = db.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    rows = db.scalars(stmt.offset(offset).limit(size)).all()
+    return rows, int(total)
+
+
+def create_availability(db: Session, **fields) -> Availability:
+    a = Availability(**fields)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def get_availability(db: Session, aid: int) -> Availability | None:
+    return db.get(Availability, aid)
+
+
+def update_availability(db: Session, aid: int, **changes) -> Availability | None:
+    a = db.get(Availability, aid)
+    if not a:
+        return None
+    for k, v in changes.items():
+        if v is not None:
+            setattr(a, k, v)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def delete_availability(db: Session, aid: int) -> bool:
+    a = db.get(Availability, aid)
+    if not a:
+        return False
+    db.delete(a)
+    db.commit()
+    return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,8 +5,10 @@ from .auth import router as auth_router
 from .db import get_engine
 from .logging_setup import configure_logging, get_logger
 from .middleware import RequestIdMiddleware, get_request_id
-from .routers_intermittents import router as intermittents_router  # type: ignore[import-untyped]
+from .routers_availabilities import router as av_router  # type: ignore[import-untyped]
+from .routers_intermittents import router as inter_router  # type: ignore[import-untyped]
 from .routers_missions import router as missions_router  # type: ignore[import-untyped]
+from .routers_planning import router as planning_router  # type: ignore[import-untyped]
 from .routers_users import router as users_router
 from .settings import get_settings
 
@@ -30,8 +32,10 @@ def create_app() -> FastAPI:
 
     app.include_router(auth_router)
     app.include_router(users_router)
-    app.include_router(intermittents_router)
+    app.include_router(inter_router)
     app.include_router(missions_router)
+    app.include_router(av_router)
+    app.include_router(planning_router)
 
     return app
 

--- a/backend/app/models_availability.py
+++ b/backend/app/models_availability.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .db import Base
+
+
+class Availability(Base):
+    __tablename__ = "availabilities"
+    __table_args__ = (
+        Index("ix_avail_inter_id", "intermittent_id"),
+        Index("ix_avail_time", "start_at", "end_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    intermittent_id: Mapped[int] = mapped_column(Integer, ForeignKey("intermittents.id"), nullable=False)
+    start_at: Mapped[datetime] = mapped_column(DateTime(timezone=False), nullable=False)
+    end_at: Mapped[datetime] = mapped_column(DateTime(timezone=False), nullable=False)
+    busy: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    note: Mapped[str | None] = mapped_column(String(200), nullable=True)

--- a/backend/app/routers_availabilities.py
+++ b/backend/app/routers_availabilities.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.orm import Session
+
+from .crud_availability import (
+    create_availability,
+    delete_availability,
+    get_availability,
+    list_availabilities,
+    update_availability,
+)
+from .deps import get_db_dep, require_auth
+from .schemas_availability import AvailabilityCreate, AvailabilityOut, AvailabilityUpdate
+
+router = APIRouter(
+    prefix="/availabilities",
+    tags=["availabilities"],
+    dependencies=[Depends(require_auth)],  # noqa: B008
+)
+
+
+@router.get("", response_model=dict)
+def list_api(
+    db: Session = Depends(get_db_dep),  # noqa: B008
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    intermittent_id: int | None = Query(None),
+    start_from: str | None = Query(None, description="ISO start of window"),
+    end_to: str | None = Query(None, description="ISO end of window"),
+) -> dict[str, Any]:
+    items, total = list_availabilities(db, page, size, intermittent_id, start_from, end_to)
+    pages = (total + size - 1) // size if size else 1
+    return {
+        "items": [AvailabilityOut.model_validate(i) for i in items],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": pages,
+    }
+
+
+@router.post("", response_model=AvailabilityOut, status_code=201)
+def create_api(payload: AvailabilityCreate, db: Session = Depends(get_db_dep)) -> AvailabilityOut:  # noqa: B008
+    a = create_availability(db, **payload.model_dump())
+    return AvailabilityOut.model_validate(a)
+
+
+@router.get("/{aid}", response_model=AvailabilityOut)
+def get_api(aid: int, db: Session = Depends(get_db_dep)) -> AvailabilityOut:  # noqa: B008
+    a = get_availability(db, aid)
+    if not a:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Availability introuvable.")
+    return AvailabilityOut.model_validate(a)
+
+
+@router.put("/{aid}", response_model=AvailabilityOut)
+def update_api(
+    aid: int, payload: AvailabilityUpdate, db: Session = Depends(get_db_dep)  # noqa: B008
+) -> AvailabilityOut:
+    a = update_availability(db, aid, **payload.model_dump())
+    if not a:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Availability introuvable.")
+    return AvailabilityOut.model_validate(a)
+
+
+@router.delete("/{aid}", status_code=204, response_class=Response)
+def delete_api(aid: int, db: Session = Depends(get_db_dep)) -> Response:  # noqa: B008
+    ok = delete_availability(db, aid)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Availability introuvable.")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers_planning.py
+++ b/backend/app/routers_planning.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .deps import get_db_dep, require_auth
+from .models_availability import Availability
+from .models_mission import Mission
+
+router = APIRouter(
+    prefix="/planning",
+    tags=["planning"],
+    dependencies=[Depends(require_auth)],  # noqa: B008
+)
+
+
+def _overlap(a_start: datetime, a_end: datetime, b_start: datetime, b_end: datetime) -> bool:
+    return a_start < b_end and b_start < a_end
+
+
+class PlanningCheckIn(BaseModel):
+    start_at: datetime
+    end_at: datetime
+    intermittent_id: int | None = None
+    exclude_mission_id: int | None = None
+
+    @field_validator("end_at")
+    @classmethod
+    def _validate_dates(cls, v: datetime, info):  # type: ignore[override]
+        start = info.data.get("start_at")
+        if start and v <= start:
+            raise ValueError("end_at must be after start_at")
+        return v
+
+
+class MissionMini(BaseModel):
+    id: int
+    title: str
+    start_at: datetime
+    end_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class AvailMini(BaseModel):
+    id: int
+    intermittent_id: int
+    start_at: datetime
+    end_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class PlanningCheckOut(BaseModel):
+    conflicts: dict[str, list[Any]]
+
+
+@router.post("/check", response_model=PlanningCheckOut)
+def check_conflicts(
+    payload: PlanningCheckIn, db: Session = Depends(get_db_dep)  # noqa: B008
+) -> PlanningCheckOut:
+    s0 = payload.start_at
+    e0 = payload.end_at
+
+    # Missions en conflit (chevauchement temps)
+    q = select(Mission)
+    if payload.exclude_mission_id:
+        q = q.where(Mission.id != payload.exclude_mission_id)
+    missions = db.scalars(q).all()
+    m_conf = [m for m in missions if _overlap(s0, e0, m.start_at, m.end_at)]
+
+    # Indisponibilites en conflit pour un intermittent (si fourni)
+    a_conf: list[Availability] = []
+    if payload.intermittent_id is not None:
+        avs = db.scalars(
+            select(Availability).where(
+                Availability.intermittent_id == payload.intermittent_id,
+                Availability.busy.is_(True),
+            )
+        ).all()
+        a_conf = [a for a in avs if _overlap(s0, e0, a.start_at, a.end_at)]
+
+    out = {
+        "missions": [MissionMini.model_validate(m).model_dump() for m in m_conf],
+        "availabilities": [AvailMini.model_validate(a).model_dump() for a in a_conf],
+    }
+    return PlanningCheckOut(conflicts=out)

--- a/backend/app/schemas_availability.py
+++ b/backend/app/schemas_availability.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class AvailabilityBase(BaseModel):
+    intermittent_id: int
+    start_at: datetime
+    end_at: datetime
+    busy: bool = Field(default=True)
+    note: str | None = None
+
+    @field_validator("end_at")
+    @classmethod
+    def _validate_dates(cls, v: datetime, info):  # type: ignore[override]
+        start = info.data.get("start_at")
+        if start and v <= start:
+            raise ValueError("end_at must be after start_at")
+        return v
+
+
+class AvailabilityCreate(AvailabilityBase):
+    pass
+
+
+class AvailabilityUpdate(BaseModel):
+    intermittent_id: int | None = None
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    busy: bool | None = None
+    note: str | None = None
+
+
+class AvailabilityOut(BaseModel):
+    id: int
+    intermittent_id: int
+    start_at: datetime
+    end_at: datetime
+    busy: bool
+    note: str | None
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_planning.py
+++ b/backend/tests/test_planning.py
@@ -1,0 +1,104 @@
+import os
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.db import Base, get_engine
+from app.main import create_app
+from app.settings import get_settings
+
+
+def _client():
+    os.environ["ADMIN_EMAIL"] = "admin@example.com"
+    os.environ["ADMIN_PASSWORD"] = "s3cret"
+    os.environ["JWT_SECRET"] = "unit-test-secret"
+    os.environ["DB_DSN"] = "sqlite://"
+    try:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    app = create_app()
+    return TestClient(app)
+
+
+def _token(c: TestClient) -> str:
+    r = c.post("/auth/token", data={"username": "admin@example.com", "password": "s3cret"})
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def _mk_mission(c: TestClient, t: str, start: datetime, end: datetime, token: str) -> int:
+    r = c.post(
+        "/missions",
+        json={"title": t, "start_at": start.isoformat(), "end_at": end.isoformat()},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _mk_avail(c: TestClient, inter_id: int, start: datetime, end: datetime, token: str) -> int:
+    r = c.post(
+        "/availabilities",
+        json={
+            "intermittent_id": inter_id,
+            "start_at": start.isoformat(),
+            "end_at": end.isoformat(),
+            "busy": True,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def test_conflict_with_other_missions_ok():
+    c = _client()
+    t = _token(c)
+    now = datetime.utcnow()
+    _mk_mission(c, "A", now + timedelta(hours=1), now + timedelta(hours=3), t)
+    b = _mk_mission(c, "B", now + timedelta(hours=2), now + timedelta(hours=4), t)
+    body = {
+        "start_at": (now + timedelta(hours=1)).isoformat(),
+        "end_at": (now + timedelta(hours=3)).isoformat(),
+    }
+    r = c.post("/planning/check", json=body, headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 200
+    mids = [m["id"] for m in r.json()["conflicts"]["missions"]]
+    assert b in mids
+
+
+def test_conflict_with_availability_ok():
+    c = _client()
+    t = _token(c)
+    now = datetime.utcnow()
+    _mk_mission(c, "A", now + timedelta(hours=5), now + timedelta(hours=6), t)
+    inter_id = 123
+    _mk_avail(c, inter_id, now + timedelta(hours=1), now + timedelta(hours=3), t)
+    body = {
+        "start_at": (now + timedelta(hours=2)).isoformat(),
+        "end_at": (now + timedelta(hours=2, minutes=30)).isoformat(),
+        "intermittent_id": inter_id,
+    }
+    r = c.post("/planning/check", json=body, headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 200
+    aids = [a["id"] for a in r.json()["conflicts"]["availabilities"]]
+    assert len(aids) == 1
+
+
+def test_no_conflicts_ko_expected_empty():
+    c = _client()
+    t = _token(c)
+    now = datetime.utcnow()
+    _mk_mission(c, "A", now + timedelta(hours=1), now + timedelta(hours=2), t)
+    body = {
+        "start_at": (now + timedelta(hours=3)).isoformat(),
+        "end_at": (now + timedelta(hours=4)).isoformat(),
+    }
+    r = c.post("/planning/check", json=body, headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 200
+    data = r.json()["conflicts"]
+    assert data["missions"] == [] and data["availabilities"] == []


### PR DESCRIPTION
## Summary
- add Availability model, CRUD, and router
- implement planning conflict check endpoint
- cover conflicts with missions and availabilities via tests

## Testing
- `python -m ruff check app tests`
- `python -m mypy app tests` *(fails: Function is missing a return type annotation)*
- `PYTHONPATH=backend pytest -q`
- `pwsh -File scripts/ps1/Backend-Test.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e814020833089a9ed421279895b