### PR TITLE
feat(audit): middleware global + GET /audits + indexes

### DIFF
--- a/backend/alembic/versions/20250822_0003_create_missions_audit.py
+++ b/backend/alembic/versions/20250822_0003_create_missions_audit.py
@@ -34,16 +34,14 @@ def upgrade() -> None:
         sa.Column("entity_id", sa.Integer(), nullable=True),
         sa.Column("payload", sa.Text(), nullable=True),
         sa.Column(
-            "created_at",
+            "ts",
             sa.DateTime(),
             nullable=False,
             server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
-    op.create_index("ix_audit_logs_request_id", "audit_logs", ["request_id"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_audit_logs_request_id", table_name="audit_logs")
     op.drop_table("audit_logs")
     op.drop_table("missions")

--- a/backend/alembic/versions/20250822_0005_audit_indexes.py
+++ b/backend/alembic/versions/20250822_0005_audit_indexes.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250822_0005"
+down_revision = "20250822_0004"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_index("ix_audit_request_id", "audit_logs", ["request_id"])
+    op.create_index("ix_audit_ts", "audit_logs", ["ts"])
+    op.create_index("ix_audit_entity", "audit_logs", ["entity"])
+    op.create_index("ix_audit_action", "audit_logs", ["action"])
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_action", table_name="audit_logs")
+    op.drop_index("ix_audit_entity", table_name="audit_logs")
+    op.drop_index("ix_audit_ts", table_name="audit_logs")
+    op.drop_index("ix_audit_request_id", table_name="audit_logs")

--- a/backend/app/audit_log.py
+++ b/backend/app/audit_log.py
@@ -9,7 +9,7 @@ from .middleware import get_request_id
 from .models_audit import AuditLog
 
 
-def write_audit_log(
+def write_audit(
     db: Session,
     actor: str,
     action: str,
@@ -27,3 +27,7 @@ def write_audit_log(
     )
     db.add(log)
     db.commit()
+
+
+# Backward compatibility
+write_audit_log = write_audit

--- a/backend/app/crud_audit.py
+++ b/backend/app/crud_audit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import Optional, Sequence
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session
+from .models_audit import AuditLog
+
+
+def list_audits(
+    db: Session,
+    page: int,
+    size: int,
+    *,
+    actor: Optional[str] = None,
+    entity: Optional[str] = None,
+    action: Optional[str] = None,
+    request_id: Optional[str] = None,
+    from_ts: Optional[str] = None,
+    to_ts: Optional[str] = None,
+) -> tuple[Sequence[AuditLog], int]:
+    if page < 1:
+        page = 1
+    size = max(1, min(size, 100))
+    offset = (page - 1) * size
+
+    stmt = select(AuditLog)
+    conds = []
+    if actor:
+        conds.append(AuditLog.actor == actor)
+    if entity:
+        conds.append(AuditLog.entity == entity)
+    if action:
+        conds.append(AuditLog.action == action)
+    if request_id:
+        conds.append(AuditLog.request_id == request_id)
+    if from_ts:
+        conds.append(AuditLog.ts >= from_ts)
+    if to_ts:
+        conds.append(AuditLog.ts <= to_ts)
+
+    if conds:
+        stmt = stmt.where(*conds)
+
+    total = db.scalar(select(func.count(AuditLog.id)).where(*conds)) or 0
+    rows = db.scalars(
+        stmt.order_by(AuditLog.ts.desc()).offset(offset).limit(size)
+    ).all()
+    return rows, int(total)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,11 +5,13 @@ from .auth import router as auth_router
 from .db import get_engine
 from .logging_setup import configure_logging, get_logger
 from .middleware import RequestIdMiddleware, get_request_id
+from .middleware_request_audit import RequestAuditMiddleware
 from .routers_availabilities import router as av_router  # type: ignore[import-untyped]
 from .routers_intermittents import router as inter_router  # type: ignore[import-untyped]
 from .routers_missions import router as missions_router  # type: ignore[import-untyped]
 from .routers_planning import router as planning_router  # type: ignore[import-untyped]
 from .routers_users import router as users_router
+from .routers_audits import router as audits_router  # type: ignore[import-untyped]
 from .settings import get_settings
 
 configure_logging()
@@ -20,7 +22,7 @@ get_engine()  # init engine early
 def create_app() -> FastAPI:
     app = FastAPI(title=get_settings().app_name)
     app.add_middleware(RequestIdMiddleware)
-
+    app.add_middleware(RequestAuditMiddleware)
     @app.get("/healthz")
     async def healthz(request: Request):
         rid = get_request_id()
@@ -36,6 +38,7 @@ def create_app() -> FastAPI:
     app.include_router(missions_router)
     app.include_router(av_router)
     app.include_router(planning_router)
+    app.include_router(audits_router)
 
     return app
 

--- a/backend/app/middleware_request_audit.py
+++ b/backend/app/middleware_request_audit.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import re
+from typing import Optional
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from .audit_log import write_audit
+from .security import decode_token
+from .db import get_sessionmaker
+
+
+class RequestAuditMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app):
+        super().__init__(app)
+        self._sess_maker = get_sessionmaker()
+
+    async def dispatch(self, request: Request, call_next):
+        response: Response = await call_next(request)
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            try:
+                actor = self._extract_actor(request)
+                entity, entity_id = self._extract_entity(request.url.path)
+                payload = {
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status": response.status_code,
+                }
+                with self._sess_maker() as db:
+                    write_audit(
+                        db,
+                        actor=actor or "-",
+                        action="request",
+                        entity=entity or "-",
+                        entity_id=entity_id or 0,
+                        payload=payload,
+                    )
+            except Exception:
+                # Ne pas casser la reponse si l'audit echoue
+                pass
+        return response
+
+    def _extract_actor(self, request: Request) -> Optional[str]:
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            token = auth.split(" ", 1)[1]
+            sub = decode_token(token)
+            if sub:
+                return sub
+        return None
+
+    def _extract_entity(self, path: str) -> tuple[str, int]:
+        parts = [p for p in path.split("/") if p]
+        entity = parts[0] if parts else "-"
+        entity_id = 0
+        if len(parts) > 1 and re.fullmatch(r"\d+", parts[1] or ""):
+            try:
+                entity_id = int(parts[1])
+            except Exception:
+                entity_id = 0
+        return entity, entity_id

--- a/backend/app/models_audit.py
+++ b/backend/app/models_audit.py
@@ -12,12 +12,12 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    request_id: Mapped[str] = mapped_column(String(100), index=True, nullable=False)
+    request_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
     actor: Mapped[str] = mapped_column(String(320), nullable=False)
-    action: Mapped[str] = mapped_column(String(50), nullable=False)
-    entity: Mapped[str] = mapped_column(String(50), nullable=False)
+    action: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    entity: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     entity_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     payload: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, server_default=func.now(), nullable=False
+    ts: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False, index=True
     )

--- a/backend/app/routers_audits.py
+++ b/backend/app/routers_audits.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+from typing import Any, Optional
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from .deps import get_db_dep, require_auth
+from .crud_audit import list_audits as list_audits_crud
+
+router = APIRouter(prefix="/audits", tags=["audits"], dependencies=[Depends(require_auth)])
+
+
+class AuditOut(BaseModel):
+    id: int
+    ts: datetime
+    actor: str
+    action: str
+    entity: str
+    entity_id: int
+    request_id: str
+    payload: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+@router.get("", response_model=dict)
+def list_audits(
+    db: Session = Depends(get_db_dep),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+    actor: Optional[str] = Query(None),
+    entity: Optional[str] = Query(None),
+    action: Optional[str] = Query(None),
+    request_id: Optional[str] = Query(None),
+    from_ts: Optional[datetime] = Query(None),
+    to_ts: Optional[datetime] = Query(None),
+) -> dict[str, Any]:
+    if from_ts and to_ts and from_ts > to_ts:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Plage temporelle invalide.",
+        )
+    items, total = list_audits_crud(
+        db,
+        page,
+        size,
+        actor=actor,
+        entity=entity,
+        action=action,
+        request_id=request_id,
+        from_ts=from_ts.isoformat() if from_ts else None,
+        to_ts=to_ts.isoformat() if to_ts else None,
+    )
+    pages = (total + size - 1) // size if size else 1
+    return {
+        "items": [AuditOut.model_validate(i) for i in items],
+        "total": total,
+        "page": page,
+        "size": size,
+        "pages": pages,
+    }

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -1,0 +1,88 @@
+import os
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+from app.main import create_app
+from app.settings import get_settings
+from app.db import Base, get_engine
+
+
+def _client():
+    os.environ["ADMIN_EMAIL"] = "admin@example.com"
+    os.environ["ADMIN_PASSWORD"] = "s3cret"
+    os.environ["JWT_SECRET"] = "unit-test-secret"
+    os.environ["DB_DSN"] = "sqlite://"
+    try:
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    engine = get_engine()
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    app = create_app()
+    return TestClient(app)
+
+
+def _token(c: TestClient) -> str:
+    r = c.post(
+        "/auth/token",
+        data={"username": "admin@example.com", "password": "s3cret"},
+    )
+    assert r.status_code == 200
+    return r.json()["access_token"]
+
+
+def test_filter_by_request_id_ok():
+    c = _client()
+    t = _token(c)
+    h = {"Authorization": f"Bearer {t}"}
+    now = datetime.utcnow()
+    r = c.post(
+        "/missions",
+        json={
+            "title": "AuditCase",
+            "start_at": now.isoformat(),
+            "end_at": (now + timedelta(hours=1)).isoformat(),
+        },
+        headers=h,
+    )
+    assert r.status_code == 201
+    rid = r.headers.get("X-Request-ID")
+    r2 = c.get(f"/audits?request_id={rid}", headers=h)
+    assert r2.status_code == 200
+    data = r2.json()
+    assert data["total"] >= 1
+    for it in data["items"]:
+        assert it["request_id"] == rid
+
+
+def test_delete_action_audited_ok():
+    c = _client()
+    t = _token(c)
+    h = {"Authorization": f"Bearer {t}"}
+    now = datetime.utcnow()
+    r = c.post(
+        "/missions",
+        json={
+            "title": "ToDelete",
+            "start_at": now.isoformat(),
+            "end_at": (now + timedelta(hours=1)).isoformat(),
+        },
+        headers=h,
+    )
+    mid = r.json()["id"]
+    r2 = c.delete(f"/missions/{mid}", headers=h)
+    assert r2.status_code == 204
+    r3 = c.get("/audits?action=delete&entity=mission", headers=h)
+    assert r3.status_code == 200
+    assert r3.json()["total"] >= 1
+
+
+def test_bad_time_range_400():
+    c = _client()
+    t = _token(c)
+    h = {"Authorization": f"Bearer {t}"}
+    r = c.get(
+        "/audits?from_ts=2025-12-31T00:00:00&to_ts=2025-01-01T00:00:00",
+        headers=h,
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary
- add RequestAuditMiddleware to log all mutating requests
- expose GET /audits with filtering and pagination
- index audit_logs for faster lookups

## Testing
- `PYTHONPATH=backend alembic -c backend/alembic.ini upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `PYTHONPATH=backend pytest backend/tests/test_audit.py -q`
- `PYTHONPATH=backend pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8910d42ec83308e425cef64acd6de