### PR TITLE
feat(frontend): skeleton React+TS+Vite+Tailwind + auth + smoke e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 *.pyc
+frontend/node_modules/
+frontend/dist/
+frontend/.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_APP_NAME=Coulisses Crew
+VITE_API_BASE=http://localhost:8001
+VITE_REQUEST_ID_HEADER=X-Request-ID

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true },
+  parser: "@typescript-eslint/parser",
+  parserOptions: { ecmaVersion: 2021, sourceType: "module", ecmaFeatures: { jsx: true } },
+  settings: { react: { version: "detect" } },
+  plugins: ["react", "react-hooks", "@typescript-eslint"],
+  extends: ["plugin:react/recommended", "plugin:@typescript-eslint/recommended"],
+  rules: {
+    "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-unused-vars": "off"
+  }
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Coulisses Crew</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "coulisses-crew-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 5173",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run src/lib",
+    "test:ui": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.24.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/react": "^16.0.0",
+    "@types/node": "^24.3.0",
+    "@types/react": "^18.3.10",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^8.40.0",
+    "@typescript-eslint/parser": "^8.40.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.21",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "jsdom": "^25.0.0",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.3",
+    "vitest": "^2.0.5",
+    "@playwright/test": "^1.47.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Outlet, Link, useNavigate, useLocation } from "react-router-dom";
+import { isAuthenticated, logout } from "./lib/auth";
+
+export default function App() {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const authed = isAuthenticated();
+
+  React.useEffect(() => {
+    if (!authed) {
+      if (loc.pathname !== "/login") nav("/login");
+    }
+  }, [authed, loc.pathname, nav]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="bg-white shadow">
+        <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
+          <h1 className="font-bold">Coulisses Crew</h1>
+          <nav className="space-x-4">
+            <Link className="hover:underline" to="/">Dashboard</Link>
+            <Link className="hover:underline" to="/users">Users</Link>
+            {authed && (
+              <button
+                className="ml-4 px-3 py-1 rounded bg-gray-200 hover:bg-gray-300"
+                onClick={() => { logout(); nav("/login"); }}
+              >Se deconnecter</button>
+            )}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { apiFetch } from "./api";
+
+describe("api", () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    // @ts-ignore
+    global.localStorage = {
+      getItem: k => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: k => { delete store[k]; },
+      clear: () => { for (const k in store) delete store[k]; }
+    };
+    vi.restoreAllMocks();
+  });
+  it("OK: ajoute Authorization si token", async () => {
+    localStorage.setItem("cc_token", "T");
+    const spy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: 1 }) });
+    global.fetch = spy as any;
+    await apiFetch("/healthz", { auth: true });
+    const args = (spy as any).mock.calls[0][1];
+    expect(args.headers["Authorization"]).toContain("Bearer T");
+  });
+  it("KO: 401 remonte erreur", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401, text: async () => "Unauthorized" }) as any;
+    await expect(apiFetch("/users", { auth: true })).rejects.toThrow(/401/);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,37 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+function reqId() { return Math.random().toString(36).slice(2); }
+
+export async function apiFetch<T>(
+  path: string,
+  opts: { method?: HttpMethod; body?: any; auth?: boolean; timeoutMs?: number } = {}
+): Promise<T> {
+  const base = import.meta.env.VITE_API_BASE || "http://localhost:8001";
+  const url = `${base}${path}`;
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 5000);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    [import.meta.env.VITE_REQUEST_ID_HEADER || "X-Request-ID"]: reqId()
+  };
+  if (opts.auth) {
+    const token = localStorage.getItem("cc_token");
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+  }
+  const res = await fetch(url, {
+    method: opts.method || "GET",
+    headers,
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+    signal: ctrl.signal
+  });
+  clearTimeout(t);
+  if (!res.ok) {
+    const msg = await safeText(res);
+    throw new Error(`${res.status} ${msg}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function safeText(res: Response): Promise<string> {
+  try { return await res.text(); } catch { return ""; }
+}

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { login, isAuthenticated, logout } from "./auth";
+
+function mockFetchOnce(status: number, body: any) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: async () => body }) as any;
+}
+
+describe("auth", () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    // @ts-ignore
+    global.localStorage = {
+      getItem: k => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: k => { delete store[k]; },
+      clear: () => { for (const k in store) delete store[k]; }
+    };
+    vi.restoreAllMocks();
+  });
+  it("OK: login et stockage token", async () => {
+    mockFetchOnce(200, { access_token: "T" });
+    await login("a@b.com", "x");
+    expect(isAuthenticated()).toBe(true);
+  });
+  it("KO: mauvais mdp -> erreur", async () => {
+    mockFetchOnce(401, {});
+    await expect(login("a@b.com", "bad")).rejects.toThrow();
+    expect(isAuthenticated()).toBe(false);
+  });
+});

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,19 @@
+export function isAuthenticated(): boolean {
+  return Boolean(localStorage.getItem("cc_token"));
+}
+
+export function logout(): void {
+  localStorage.removeItem("cc_token");
+}
+
+export async function login(email: string, password: string): Promise<void> {
+  const base = import.meta.env.VITE_API_BASE || "http://localhost:8001";
+  const res = await fetch(`${base}/auth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ username: email, password })
+  });
+  if (!res.ok) throw new Error("Identifiants invalides");
+  const data = (await res.json()) as { access_token: string };
+  localStorage.setItem("cc_token", data.access_token);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,30 @@
+import "./styles.css";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import App from "./App";
+import Login from "./pages/Login";
+import Dashboard from "./pages/Dashboard";
+import Users from "./pages/Users";
+import { isAuthenticated } from "./lib/auth";
+
+const router = createBrowserRouter([
+  { path: "/login", element: <Login /> },
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      { index: true, element: <Dashboard /> },
+      { path: "users", element: <Users /> }
+    ]
+  }
+]);
+
+function GuardedRouter() {
+  const authed = isAuthenticated();
+  // Redirection simple cote pages elles-memes
+  return <RouterProvider router={router} />;
+}
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<GuardedRouter />);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { apiFetch } from "../lib/api";
+
+export default function Dashboard() {
+  const [status, setStatus] = React.useState<string>("...");
+  React.useEffect(() => {
+    apiFetch<{ status: string }>("/healthz").then(r => setStatus(r.status)).catch(() => setStatus("KO"));
+  }, []);
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Dashboard</h2>
+      <div className="p-3 rounded bg-white shadow inline-block">Healthz: {status}</div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { login, isAuthenticated } from "../lib/auth";
+
+export default function Login() {
+  const [email, setEmail] = React.useState("admin@example.com");
+  const [password, setPassword] = React.useState("admin");
+  const [err, setErr] = React.useState<string | null>(null);
+  const nav = useNavigate();
+
+  React.useEffect(() => {
+    if (isAuthenticated()) nav("/");
+  }, [nav]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      await login(email, password);
+      nav("/");
+    } catch (ex: any) {
+      setErr(ex?.message || "Erreur de connexion");
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-16 bg-white p-6 rounded shadow">
+      <h2 className="text-xl font-semibold mb-4">Connexion</h2>
+      {err && <div className="mb-3 text-red-600 text-sm">{err}</div>}
+      <form onSubmit={onSubmit} className="space-y-3">
+        <input
+          className="w-full border px-3 py-2 rounded"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full border px-3 py-2 rounded"
+          placeholder="Mot de passe"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <button className="w-full bg-gray-900 text-white py-2 rounded">Se connecter</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { apiFetch } from "../lib/api";
+
+type User = { id: number; email: string; full_name?: string | null; is_active: boolean };
+
+export default function Users() {
+  const [items, setItems] = React.useState<User[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [total, setTotal] = React.useState(0);
+  const size = 10;
+
+  React.useEffect(() => {
+    apiFetch<{ items: User[]; total: number }>(`/users?page=${page}&size=${size}`, { auth: true })
+      .then(r => { setItems(r.items); setTotal(r.total); })
+      .catch(() => { setItems([]); setTotal(0); });
+  }, [page]);
+
+  const pages = Math.max(1, Math.ceil(total / size));
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-3">Users</h2>
+      <div className="bg-white rounded shadow overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead><tr className="bg-gray-100 text-left"> <th className="p-2">ID</th><th className="p-2">Email</th><th className="p-2">Actif</th> </tr></thead>
+          <tbody>
+            {items.map(u => (
+              <tr key={u.id} className="border-t">
+                <td className="p-2">{u.id}</td>
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">{u.is_active ? "oui" : "non"}</td>
+              </tr>
+            ))}
+            {items.length === 0 && (
+              <tr><td className="p-2" colSpan={3}>Aucun utilisateur</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-3 flex items-center gap-2">
+        <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50"
+          onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>Prev</button>
+        <span>Page {page} / {pages}</span>
+        <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50"
+          onClick={() => setPage(p => Math.min(pages, p + 1))} disabled={page >= pages}>Next</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from "tailwindcss";
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: []
+} satisfies Config;

--- a/frontend/tests/e2e.spec.ts
+++ b/frontend/tests/e2e.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+const APP = process.env.APP_URL || "http://localhost:5173";
+
+test("smoke: page de login visible", async ({ page }) => {
+  await page.goto(APP);
+  await expect(page.getByText("Connexion")).toBeVisible();
+});
+
+test("protected: redirection vers login", async ({ page }) => {
+  await page.goto(APP + "/users");
+  await expect(page.getByText("Connexion")).toBeVisible();
+});
+
+// Optionnel: test avec backend reel si E2E_WITH_BACKEND=1
+// Admin doit exister: admin@example.com / admin
+const WITH_BACKEND = process.env.E2E_WITH_BACKEND === "1";
+(WITH_BACKEND ? test : test.skip)("login + dashboard", async ({ page }) => {
+  await page.goto(APP);
+  await page.getByPlaceholder("Email").fill("admin@example.com");
+  await page.getByPlaceholder("Mot de passe").fill("admin");
+  await page.getByRole("button", { name: "Se connecter" }).click();
+  await expect(page.getByText("Dashboard")).toBeVisible();
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": false,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173, strictPort: true }
+});

--- a/scripts/ps1/Frontend-Build.ps1
+++ b/scripts/ps1/Frontend-Build.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Set-Location (Join-Path (Resolve-Path (Join-Path (Split-Path $PSCommandPath) "....")) "frontend")
+cmd /c npm ci
+cmd /c npm run build
+if ($LASTEXITCODE -ne 0){ Write-Host "[ERR] build KO" -ForegroundColor Red; exit 10 }
+Write-Host "[OK] build OK" -ForegroundColor Green
+exit 0

--- a/scripts/ps1/Frontend-Dev.ps1
+++ b/scripts/ps1/Frontend-Dev.ps1
@@ -1,0 +1,15 @@
+Param([switch]$Reinstall)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Ok($m){ Write-Host "[OK] $m" -ForegroundColor Green }
+function Err($m){ Write-Host "[ERR] $m" -ForegroundColor Red }
+
+try {
+$root = Resolve-Path (Join-Path (Split-Path $PSCommandPath) "....")
+Set-Location (Join-Path $root "frontend")
+if ($Reinstall -or -not (Test-Path "node_modules")) { cmd /c npm ci }
+Ok "Deps installees."
+cmd /c npm run dev
+exit 0
+} catch { Err $_.Exception.Message; exit 10 }

--- a/scripts/ps1/Frontend-E2E.ps1
+++ b/scripts/ps1/Frontend-E2E.ps1
@@ -1,0 +1,12 @@
+Param([switch]$WithBackend)
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Set-Location (Join-Path (Resolve-Path (Join-Path (Split-Path $PSCommandPath) "....")) "frontend")
+cmd /c npm ci
+cmd /c npx playwright install
+if ($WithBackend) { $Env:E2E_WITH_BACKEND = "1" }
+$Env:APP_URL = $Env:APP_URL -or "http://localhost:5173"
+cmd /c npx playwright test
+if ($LASTEXITCODE -ne 0){ Write-Host "[ERR] e2e KO" -ForegroundColor Red; exit 10 }
+Write-Host "[OK] e2e OK" -ForegroundColor Green
+exit 0

--- a/scripts/ps1/Frontend-Test.ps1
+++ b/scripts/ps1/Frontend-Test.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+Set-Location (Join-Path (Resolve-Path (Join-Path (Split-Path $PSCommandPath) "....")) "frontend")
+cmd /c npm ci
+cmd /c npm run lint
+if ($LASTEXITCODE -ne 0){ exit 10 }
+cmd /c npm run typecheck
+if ($LASTEXITCODE -ne 0){ exit 10 }
+cmd /c npm test
+if ($LASTEXITCODE -ne 0){ exit 10 }
+Write-Host "[OK] tests/lint/typecheck OK" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary
- scaffold React+TS+Vite frontend with Tailwind
- add auth flow, dashboard and user list pages
- provide API client, unit tests and PowerShell helpers

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint`
- `npm run typecheck`
- `npm test`
- `npx playwright test` *(fails: Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_68a893db2f64833085214dffced6eff3