### PR TITLE
feat(frontend): page Intermittents (liste + recherche + pagination)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --port 5173",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run src/lib",
+    "test": "vitest run src",
     "test:ui": "vitest"
   },
   "dependencies": {
@@ -18,6 +18,8 @@
     "react-router-dom": "^6.24.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.47.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^24.3.0",
@@ -30,12 +32,12 @@
     "eslint": "^9.9.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "globals": "^16.3.0",
     "jsdom": "^25.0.0",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
     "vite": "^5.4.3",
-    "vitest": "^2.0.5",
-    "@playwright/test": "^1.47.0"
+    "vitest": "^2.0.5"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,11 +7,7 @@ export default function App() {
   const loc = useLocation();
   const authed = isAuthenticated();
 
-  React.useEffect(() => {
-    if (!authed) {
-      if (loc.pathname !== "/login") nav("/login");
-    }
-  }, [authed, loc.pathname, nav]);
+  React.useEffect(() => { if (!authed && loc.pathname !== "/login") nav("/login"); }, [authed, loc.pathname, nav]);
 
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
@@ -21,11 +17,9 @@ export default function App() {
           <nav className="space-x-4">
             <Link className="hover:underline" to="/">Dashboard</Link>
             <Link className="hover:underline" to="/users">Users</Link>
+            <Link className="hover:underline" to="/intermittents">Intermittents</Link>
             {authed && (
-              <button
-                className="ml-4 px-3 py-1 rounded bg-gray-200 hover:bg-gray-300"
-                onClick={() => { logout(); nav("/login"); }}
-              >Se deconnecter</button>
+              <button className="ml-4 px-3 py-1 rounded bg-gray-200 hover:bg-gray-300" onClick={() => { logout(); nav("/login"); }}>Se deconnecter</button>
             )}
           </nav>
         </div>

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+export default function Pagination({ page, pages, onPrev, onNext }:{ page:number; pages:number; onPrev:()=>void; onNext:()=>void }){
+  return (
+    <div className="flex items-center gap-2">
+      <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50" onClick={onPrev} disabled={page<=1}>Prev</button>
+      <span>Page {page} / {pages}</span>
+      <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50" onClick={onNext} disabled={page>=pages}>Next</button>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,7 @@ import App from "./App";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
-import { isAuthenticated } from "./lib/auth";
+import Intermittents from "./pages/Intermittents";
 
 const router = createBrowserRouter([
   { path: "/login", element: <Login /> },
@@ -15,16 +15,11 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       { index: true, element: <Dashboard /> },
-      { path: "users", element: <Users /> }
+      { path: "users", element: <Users /> },
+      { path: "intermittents", element: <Intermittents /> }
     ]
   }
 ]);
 
-function GuardedRouter() {
-  const authed = isAuthenticated();
-  // Redirection simple cote pages elles-memes
-  return <RouterProvider router={router} />;
-}
-
 const root = createRoot(document.getElementById("root")!);
-root.render(<GuardedRouter />);
+root.render(<RouterProvider router={router} />);

--- a/frontend/src/pages/Intermittents.test.tsx
+++ b/frontend/src/pages/Intermittents.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import Intermittents from "./Intermittents";
+
+function mockFetchOnce(status: number, body: any) {
+  (global as any).fetch = vi.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: async () => body, text: async () => JSON.stringify(body) });
+}
+
+describe("Intermittents page", () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    (global as any).localStorage = {
+      getItem: k => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: k => { delete store[k]; },
+      clear: () => { for (const k in store) delete store[k]; }
+    };
+    localStorage.setItem("cc_token", "T");
+    vi.restoreAllMocks();
+  });
+
+  it("OK: affiche une ligne depuis API", async () => {
+    mockFetchOnce(200, { items: [{ id:1, email:"a@ex.com", is_active:true }], total:1, page:1, size:20, pages:1 });
+    render(<Intermittents />);
+    await waitFor(() => expect(screen.getByText("a@ex.com")).toBeInTheDocument());
+  });
+
+  it("KO: 401 -> message d'erreur", async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({ ok:false, status:401, text: async () => "Unauthorized" });
+    render(<Intermittents />);
+    await waitFor(() => expect(screen.getByText(/401/)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/Intermittents.tsx
+++ b/frontend/src/pages/Intermittents.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { apiFetch } from "../lib/api";
+import Pagination from "../components/Pagination";
+
+type Intermittent = {
+  id: number;
+  email: string;
+  first_name?: string | null;
+  last_name?: string | null;
+  phone?: string | null;
+  skills?: string | null;
+  is_active: boolean;
+};
+
+type ListResp = { items: Intermittent[]; total: number; page: number; size: number; pages: number };
+
+export default function Intermittents() {
+  const [items, setItems] = React.useState<Intermittent[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [total, setTotal] = React.useState(0);
+  const [size] = React.useState(20);
+  const [q, setQ] = React.useState("");
+  const [skill, setSkill] = React.useState("");
+  const [active, setActive] = React.useState<string>("");
+  const [loading, setLoading] = React.useState(false);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  async function load() {
+    setLoading(true); setErr(null);
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("size", String(size));
+    if (q) params.set("q", q);
+    if (skill) params.set("skill", skill);
+    if (active === "true" || active === "false") params.set("active", active);
+    try {
+      const r = await apiFetch<ListResp>(`/intermittents?${params.toString()}`, { auth: true, timeoutMs: 8000 });
+      setItems(r.items); setTotal(r.total);
+    } catch (e: any) {
+      setItems([]); setTotal(0); setErr(e?.message || "Erreur");
+    } finally { setLoading(false); }
+  }
+
+  React.useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [page]);
+
+  function onSearch(e: React.FormEvent) { e.preventDefault(); setPage(1); load(); }
+
+  const pages = Math.max(1, Math.ceil(total / size));
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-3">Intermittents</h2>
+      <form onSubmit={onSearch} className="bg-white p-3 rounded shadow mb-3 grid grid-cols-1 md:grid-cols-4 gap-2">
+        <input className="border px-2 py-1 rounded" placeholder="Recherche (email/nom/skills)" value={q} onChange={e=>setQ(e.target.value)} />
+        <input className="border px-2 py-1 rounded" placeholder="Skill (ex: son)" value={skill} onChange={e=>setSkill(e.target.value)} />
+        <select className="border px-2 py-1 rounded" value={active} onChange={e=>setActive(e.target.value)}>
+          <option value="">Actif: tous</option>
+          <option value="true">Actifs</option>
+          <option value="false">Inactifs</option>
+        </select>
+        <button className="bg-gray-900 text-white px-3 py-1 rounded">Rechercher</button>
+      </form>
+
+      {err && <div className="mb-2 text-red-600 text-sm">{err}</div>}
+
+      <div className="bg-white rounded shadow overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="p-2">ID</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Nom</th>
+              <th className="p-2">Phone</th>
+              <th className="p-2">Skills</th>
+              <th className="p-2">Actif</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(it => (
+              <tr key={it.id} className="border-t">
+                <td className="p-2">{it.id}</td>
+                <td className="p-2">{it.email}</td>
+                <td className="p-2">{[it.first_name, it.last_name].filter(Boolean).join(" ")}</td>
+                <td className="p-2">{it.phone || "-"}</td>
+                <td className="p-2">{it.skills || "-"}</td>
+                <td className="p-2">{it.is_active ? "oui" : "non"}</td>
+              </tr>
+            ))}
+            {(!loading && items.length === 0) && (
+              <tr><td className="p-2" colSpan={6}>Aucun intermittent</td></tr>
+            )}
+            {loading && (
+              <tr><td className="p-2" colSpan={6}>Chargement...</td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3">
+        <Pagination page={page} pages={pages} onPrev={()=>setPage(p=>Math.max(1,p-1))} onNext={()=>setPage(p=>Math.min(pages,p+1))} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Intermittents page with search, filters, pagination
- expose `/intermittents` route and navigation link
- cover Intermittents page with unit tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a89f1d283883308c55b0738a9b9b05