### PR TITLE
feat(frontend): add missions pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
             <Link className="hover:underline" to="/">Dashboard</Link>
             <Link className="hover:underline" to="/users">Users</Link>
             <Link className="hover:underline" to="/intermittents">Intermittents</Link>
+            <Link className="hover:underline" to="/missions">Missions</Link>
             {authed && (
               <button className="ml-4 px-3 py-1 rounded bg-gray-200 hover:bg-gray-300" onClick={() => { logout(); nav("/login"); }}>Se deconnecter</button>
             )}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,8 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Users from "./pages/Users";
 import Intermittents from "./pages/Intermittents";
+import Missions from "./pages/Missions";
+import MissionForm from "./pages/MissionForm";
 
 const router = createBrowserRouter([
   { path: "/login", element: <Login /> },
@@ -16,7 +18,10 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Dashboard /> },
       { path: "users", element: <Users /> },
-      { path: "intermittents", element: <Intermittents /> }
+      { path: "intermittents", element: <Intermittents /> },
+      { path: "missions", element: <Missions /> },
+      { path: "missions/new", element: <MissionForm /> },
+      { path: "missions/:id", element: <MissionForm /> }
     ]
   }
 ]);

--- a/frontend/src/pages/Intermittents.test.tsx
+++ b/frontend/src/pages/Intermittents.test.tsx
@@ -13,9 +13,9 @@ describe("Intermittents page", () => {
   beforeEach(() => {
     const store: Record<string, string> = {};
     (global as any).localStorage = {
-      getItem: k => (k in store ? store[k] : null),
-      setItem: (k, v) => { store[k] = v; },
-      removeItem: k => { delete store[k]; },
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
       clear: () => { for (const k in store) delete store[k]; }
     };
     localStorage.setItem("cc_token", "T");

--- a/frontend/src/pages/MissionForm.tsx
+++ b/frontend/src/pages/MissionForm.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { apiFetch } from "../lib/api";
+
+type Mission = {
+  id?: number;
+  title: string;
+  description?: string | null;
+  location?: string | null;
+  start_at: string;
+  end_at: string;
+  status?: string;
+};
+
+export default function MissionForm(){
+  const params = useParams();
+  const nav = useNavigate();
+  const [model, setModel] = React.useState<Mission>({ title:"", description:"", location:"", start_at:"", end_at:"" });
+  const [err, setErr] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const isEdit = Boolean(params.id);
+
+  React.useEffect(() => {
+    async function fetchOne(){
+      if (!isEdit) return;
+      try {
+        const r = await apiFetch<Mission>(`/missions/${params.id}`, { auth: true });
+        setModel(r);
+      } catch(e:any){ setErr(e?.message||"Erreur"); }
+    }
+    fetchOne();
+  }, [isEdit, params.id]);
+
+  async function onSubmit(e: React.FormEvent){
+    e.preventDefault(); setErr(null); setLoading(true);
+    try {
+      const body = normalize(model);
+      if (isEdit) await apiFetch(`/missions/${params.id}`, { method:"PUT", auth:true, body });
+      else await apiFetch(`/missions`, { method:"POST", auth:true, body });
+      nav("/missions");
+    } catch(e:any){ setErr(e?.message||"Erreur enregistrement"); }
+    finally { setLoading(false); }
+  }
+
+  return (
+    <div className="max-w-xl">
+      <h2 className="text-xl font-semibold mb-3">{isEdit?"Modifier":"Nouvelle"} mission</h2>
+      {err && <div className="mb-2 text-red-600 text-sm">{err}</div>}
+      <form onSubmit={onSubmit} className="bg-white p-4 rounded shadow space-y-3">
+        <input className="w-full border px-3 py-2 rounded" placeholder="Titre" value={model.title} onChange={e=>setModel({...model,title:e.target.value})} required />
+        <input className="w-full border px-3 py-2 rounded" placeholder="Lieu" value={model.location||""} onChange={e=>setModel({...model,location:e.target.value})} />
+        <textarea className="w-full border px-3 py-2 rounded" placeholder="Description" value={model.description||""} onChange={e=>setModel({...model,description:e.target.value})} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          <label className="text-sm">Debut
+            <input className="w-full border px-3 py-2 rounded" type="datetime-local" value={toLocalInput(model.start_at)} onChange={e=>setModel({...model,start_at:fromLocalInput(e.target.value)})} required />
+          </label>
+          <label className="text-sm">Fin
+            <input className="w-full border px-3 py-2 rounded" type="datetime-local" value={toLocalInput(model.end_at)} onChange={e=>setModel({...model,end_at:fromLocalInput(e.target.value)})} required />
+          </label>
+        </div>
+        <div className="flex gap-2">
+          <button disabled={loading} className="bg-gray-900 text-white px-3 py-1 rounded">Enregistrer</button>
+          <button type="button" className="px-3 py-1 rounded bg-gray-200" onClick={()=>nav("/missions")}>Annuler</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export function normalize(m: Mission){
+  return {
+    title: m.title,
+    description: m.description || null,
+    location: m.location || null,
+    start_at: m.start_at || new Date().toISOString(),
+    end_at: m.end_at || new Date(Date.now()+3600000).toISOString(),
+  };
+}
+
+function toLocalInput(iso: string){
+  if (!iso) return "";
+  const d = new Date(iso);
+  const pad=(n:number)=>String(n).padStart(2,"0");
+  const y=d.getFullYear(), mo=pad(d.getMonth()+1), da=pad(d.getDate());
+  const h=pad(d.getHours()), mi=pad(d.getMinutes());
+  return `${y}-${mo}-${da}T${h}:${mi}`;
+}
+function fromLocalInput(v: string){
+  if (!v) return "";
+  // v est local "YYYY-MM-DDTHH:mm" -> ISO
+  const d = new Date(v);
+  return d.toISOString();
+}
+

--- a/frontend/src/pages/Missions.test.tsx
+++ b/frontend/src/pages/Missions.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import "@testing-library/jest-dom/vitest";
+import MissionForm, { normalize } from "./MissionForm";
+import Missions from "./Missions";
+
+function mockFetchOnce(status: number, body: any) {
+  (global as any).fetch = vi.fn().mockResolvedValue({ ok: status >= 200 && status < 300, status, json: async () => body, text: async () => JSON.stringify(body) });
+}
+
+describe("MissionForm", () => {
+  beforeEach(() => { localStorage.setItem("cc_token","T"); vi.restoreAllMocks(); });
+  it("OK: normalize renseigne ISO", () => {
+    const out = normalize({ title:"A", start_at:"", end_at:"" });
+    expect(out.start_at).toMatch(/T/);
+    expect(out.end_at).toMatch(/T/);
+  });
+});
+
+describe("Missions list", () => {
+  beforeEach(() => { localStorage.setItem("cc_token","T"); vi.restoreAllMocks(); });
+  it("OK: render list + bouton publier", async () => {
+    mockFetchOnce(200, { items:[{ id:1, title:"A", start_at:new Date().toISOString(), end_at:new Date().toISOString(), status:"draft" }], total:1, page:1, size:10, pages:1 });
+    render(<MemoryRouter><Missions /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText("A")).toBeInTheDocument());
+  });
+  it("KO: API 401 -> message", async () => {
+    (global as any).fetch = vi.fn().mockResolvedValue({ ok:false, status:401, text: async () => "Unauthorized" });
+    render(<MemoryRouter><Missions /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText(/401/)).toBeInTheDocument());
+  });
+});
+

--- a/frontend/src/pages/Missions.tsx
+++ b/frontend/src/pages/Missions.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { apiFetch } from "../lib/api";
+
+type Mission = {
+  id: number;
+  title: string;
+  description?: string | null;
+  location?: string | null;
+  start_at: string;
+  end_at: string;
+  status: string;
+  published_at?: string | null;
+};
+
+type ListResp = { items: Mission[]; total: number; page: number; size: number; pages: number };
+
+export default function Missions() {
+  const [items, setItems] = React.useState<Mission[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [total, setTotal] = React.useState(0);
+  const [size] = React.useState(10);
+  const [q, setQ] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [err, setErr] = React.useState<string | null>(null);
+  const nav = useNavigate();
+
+  async function load() {
+    setLoading(true); setErr(null);
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    params.set("size", String(size));
+    if (q) params.set("q", q);
+    try {
+      const r = await apiFetch<ListResp>(`/missions?${params.toString()}`, { auth: true, timeoutMs: 8000 });
+      setItems(r.items); setTotal(r.total);
+    } catch (e: any) {
+      setItems([]); setTotal(0); setErr(e?.message || "Erreur");
+    } finally { setLoading(false); }
+  }
+
+  React.useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [page]);
+
+  function onSearch(e: React.FormEvent) { e.preventDefault(); setPage(1); load(); }
+
+  async function action(id: number, kind: "publish"|"duplicate"|"delete") {
+    try {
+      if (kind === "publish") await apiFetch(`/missions/${id}/publish`, { method: "POST", auth: true });
+      if (kind === "duplicate") await apiFetch(`/missions/${id}/duplicate`, { method: "POST", auth: true });
+      if (kind === "delete") await apiFetch(`/missions/${id}`, { method: "DELETE", auth: true });
+      await load();
+    } catch (e: any) { setErr(e?.message || "Erreur action"); }
+  }
+
+  const pages = Math.max(1, Math.ceil(total / size));
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-xl font-semibold">Missions</h2>
+        <button
+          className="bg-gray-900 text-white px-3 py-1 rounded"
+          onClick={() => nav("/missions/new")}
+        >Nouvelle</button>
+      </div>
+      <form onSubmit={onSearch} className="bg-white p-3 rounded shadow mb-3 flex gap-2">
+        <input className="border px-2 py-1 rounded flex-1" placeholder="Recherche" value={q} onChange={e=>setQ(e.target.value)} />
+        <button className="bg-gray-900 text-white px-3 py-1 rounded">Rechercher</button>
+      </form>
+
+      {err && <div className="mb-2 text-red-600 text-sm">{err}</div>}
+
+      <div className="bg-white rounded shadow overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="p-2">ID</th>
+              <th className="p-2">Titre</th>
+              <th className="p-2">Lieu</th>
+              <th className="p-2">Debut</th>
+              <th className="p-2">Fin</th>
+              <th className="p-2">Statut</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(m => (
+              <tr key={m.id} className="border-t">
+                <td className="p-2">{m.id}</td>
+                <td className="p-2"><Link className="text-blue-700 hover:underline" to={`/missions/${m.id}`}>{m.title}</Link></td>
+                <td className="p-2">{m.location || "-"}</td>
+                <td className="p-2">{fmt(m.start_at)}</td>
+                <td className="p-2">{fmt(m.end_at)}</td>
+                <td className="p-2">{m.status}</td>
+                <td className="p-2 space-x-2">
+                  <button className="px-2 py-0.5 bg-gray-200 rounded disabled:opacity-50" disabled={m.status==="published"} onClick={()=>action(m.id,"publish")}>Publier</button>
+                  <button className="px-2 py-0.5 bg-gray-200 rounded" onClick={()=>action(m.id,"duplicate")}>Dupliquer</button>
+                  <button className="px-2 py-0.5 bg-red-200 rounded" onClick={()=>action(m.id,"delete")}>Supprimer</button>
+                </td>
+              </tr>
+            ))}
+            {(!loading && items.length === 0) && (
+              <tr><td className="p-2" colSpan={7}>Aucune mission</td></tr>
+            )}
+            {loading && (<tr><td className="p-2" colSpan={7}>Chargement...</td></tr>)}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50" onClick={()=>setPage(p=>Math.max(1,p-1))} disabled={page<=1}>Prev</button>
+        <span>Page {page} / {pages}</span>
+        <button className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50" onClick={()=>setPage(p=>Math.min(pages,p+1))} disabled={page>=pages}>Next</button>
+      </div>
+    </div>
+  );
+}
+
+function fmt(s: string){ try { return new Date(s).toLocaleString(); } catch { return s; } }
+


### PR DESCRIPTION
## Summary
- add missions list with search, pagination, and publish/duplicate/delete actions
- add mission create/edit form with ISO normalization
- wire missions routes and nav link

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8a219885883308d7fe55ecf9d6a03